### PR TITLE
Add cancel button in add and edit forms

### DIFF
--- a/views/listings/edit.ejs
+++ b/views/listings/edit.ejs
@@ -42,7 +42,10 @@
                     <div class="valid-feedback" aria-live="assertive">Country name looks good!</div>
                     <div class="invalid-feedback" aria-live="assertive">Please enter the country name</div>
                 </div>
-                <button class="btn btn-dark mb-4"><i class="fa-solid fa-check"></i> Update</button>
+                <div class="btns mt-3 mb-4">
+                    <button class="btn btn-dark"><i class="fa-solid fa-check"></i> Update</button>
+                    <a href="/listings/<%= listing._id %>" class="btn btn-dark"><i class="fa-solid fa-xmark"></i> Cancel</a>
+                </div>
             </form>
         </div>
     </div>

--- a/views/listings/new.ejs
+++ b/views/listings/new.ejs
@@ -40,7 +40,10 @@
                     <div class="valid-feedback" aria-live="assertive">Country name looks good!</div>
                     <div class="invalid-feedback" aria-live="assertive">Please enter the country name</div>
                 </div>
-                <button class="btn btn-dark add-btn mb-4"><i class="fa-solid fa-plus"></i> Add</button>
+                <div class="btns mt-3 mb-4">
+                    <button class="btn btn-dark add-btn"><i class="fa-solid fa-plus"></i> Add</button>
+                    <a href="/listings" class="btn btn-dark"><i class="fa-solid fa-xmark"></i> Cancel</a>
+                </div>
             </form>
         </div>
     </div>


### PR DESCRIPTION
This PR adds a Cancel button to both Add and Edit listing forms.

- Provides a clear way for users to exit without submitting
- Prevents accidental submissions
- Uses valid HTML and consistent UI patterns

Fixes #4 
